### PR TITLE
Add hadolint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ node_js: 10
 services:
   - docker
 
+env:
+  HADOLINT: "${HOME}/hadolint"
 script:
+  - curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v1.16.0/hadolint-$(uname -s)-$(uname -m)"
+    && chmod 700 ${HADOLINT}
+  - git ls-files --exclude='Dockerfile*' --ignored | xargs --max-lines=1 ${HADOLINT}
   - docker login -u="$DOCKER_LOGIN" -p="$DOCKER_PASSWORD" quay.io
   - ./build.sh
   - sudo ./test.sh
-
 deploy:
   provider: script
   script: ./deploy.sh

--- a/php-apache-shell/5.6/Dockerfile
+++ b/php-apache-shell/5.6/Dockerfile
@@ -2,8 +2,20 @@ FROM quay.io/hyperone/php-apache:5.6
 LABEL maintainer="HyperOne"
 ENV WP_CLI_VERSION="2.1.0"
 ENV H1_CLI_VERSION="1.5.1"
+ENV WGET_VERSION="1.18-5+deb9u3"
+ENV NANO_VERSION="2.7.4-1"
+ENV VIM_VERSION="2:8.0.0197-4+deb9u1"
+ENV MARIADB_CLIENT_VERSION="10.1.38-0+deb9u1"
+ENV OPENSSH_SFTP_VERSION="1:7.4p1-10+deb9u6"
+ENV MC_VERSION="3:4.8.18-1"
 RUN apt-get update \
-&& apt-get install -y --no-install-recommends wget nano mc vim mariadb-client openssh-sftp-server \
+&& apt-get install -y --no-install-recommends \
+wget="$WGET_VERSION" \
+nano="$NANO_VERSION" \
+mc="$MC_VERSION" \
+vim="$VIM_VERSION" \
+mariadb-client="$MARIADB_CLIENT_VERSION" \
+openssh-sftp-server="$OPENSSH_SFTP_VERSION" \
 && rm -rf /var/lib/apt/lists/*
 RUN curl -s -L "https://github.com/wp-cli/wp-cli/releases/download/v${WP_CLI_VERSION}/wp-cli-${WP_CLI_VERSION}.phar" -o /usr/local/bin/wp \
 && chmod +x /usr/local/bin/wp

--- a/php-apache-shell/7.2/Dockerfile
+++ b/php-apache-shell/7.2/Dockerfile
@@ -2,8 +2,20 @@ FROM quay.io/hyperone/php-apache:7.2
 LABEL maintainer="HyperOne"
 ENV WP_CLI_VERSION="2.1.0"
 ENV H1_CLI_VERSION="1.5.1"
+ENV WGET_VERSION="1.18-5+deb9u3"
+ENV NANO_VERSION="2.7.4-1"
+ENV VIM_VERSION="2:8.0.0197-4+deb9u1"
+ENV MARIADB_CLIENT_VERSION="10.1.38-0+deb9u1"
+ENV OPENSSH_SFTP_VERSION="1:7.4p1-10+deb9u6"
+ENV MC_VERSION="3:4.8.18-1"
 RUN apt-get update \
-&& apt-get install -y --no-install-recommends wget nano mc vim mariadb-client openssh-sftp-server \
+&& apt-get install -y --no-install-recommends \
+wget="$WGET_VERSION" \
+nano="$NANO_VERSION" \
+mc="$MC_VERSION" \
+vim="$VIM_VERSION" \
+mariadb-client="$MARIADB_CLIENT_VERSION" \
+openssh-sftp-server="$OPENSSH_SFTP_VERSION" \
 && rm -rf /var/lib/apt/lists/*
 RUN curl -s -L "https://github.com/wp-cli/wp-cli/releases/download/v${WP_CLI_VERSION}/wp-cli-${WP_CLI_VERSION}.phar" -o /usr/local/bin/wp \
 && chmod +x /usr/local/bin/wp

--- a/php-apache-shell/base/Dockerfile
+++ b/php-apache-shell/base/Dockerfile
@@ -2,8 +2,20 @@ FROM quay.io/hyperone/php-apache:%%PHP_VERSION%%
 LABEL maintainer="HyperOne"
 ENV WP_CLI_VERSION="2.1.0"
 ENV H1_CLI_VERSION="1.5.1"
+ENV WGET_VERSION="1.18-5+deb9u3"
+ENV NANO_VERSION="2.7.4-1"
+ENV VIM_VERSION="2:8.0.0197-4+deb9u1"
+ENV MARIADB_CLIENT_VERSION="10.1.38-0+deb9u1"
+ENV OPENSSH_SFTP_VERSION="1:7.4p1-10+deb9u6"
+ENV MC_VERSION="3:4.8.18-1"
 RUN apt-get update \
-&& apt-get install -y --no-install-recommends wget nano mc vim mariadb-client openssh-sftp-server \
+&& apt-get install -y --no-install-recommends \
+wget="$WGET_VERSION" \
+nano="$NANO_VERSION" \
+mc="$MC_VERSION" \
+vim="$VIM_VERSION" \
+mariadb-client="$MARIADB_CLIENT_VERSION" \
+openssh-sftp-server="$OPENSSH_SFTP_VERSION" \
 && rm -rf /var/lib/apt/lists/*
 RUN curl -s -L "https://github.com/wp-cli/wp-cli/releases/download/v${WP_CLI_VERSION}/wp-cli-${WP_CLI_VERSION}.phar" -o /usr/local/bin/wp \
 && chmod +x /usr/local/bin/wp

--- a/php-apache/5.6/Dockerfile
+++ b/php-apache/5.6/Dockerfile
@@ -2,16 +2,15 @@ FROM chialab/php:5.6-apache
 LABEL maintainer="HyperOne"
 LABEL rbx.shell_image="quay.io/hyperone/php-apache-shell:5.6"
 RUN rm -r /var/www/html && ln -s /data/public /var/www/html
-RUN echo "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_$(uname -m | sed 's/_/-/g').tar.gz"
-RUN curl "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_$(uname -m | sed 's/_/-/g').tar.gz" -o /tmp/ioncube.tar.gz \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -s "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_$(uname -m | sed 's/_/-/g').tar.gz" -o /tmp/ioncube.tar.gz \
 && extension_dir=$(php -i | sed -n -E '/extension_dir/s/^extension_dir.+?=> (.+?)/\1/gp') \
 && tar -xzvf /tmp/ioncube.tar.gz --strip-components=1 -C "$extension_dir" "ioncube/ioncube_loader_lin_5.6.so" \
 && chown root:staff "$extension_dir/ioncube_loader_lin_5.6.so" \
-&& echo "zend_extension = $extension_dir/ioncube_loader_lin_5.6.so" > /usr/local/etc/php/php.ini \
+&& printf "zend_extension = %s/ioncube_loader_lin_5.6.so" "$extension_dir" > /usr/local/etc/php/php.ini \
 && rm /tmp/ioncube.tar.gz
 RUN adduser -uid 23456 --disabled-password --gecos "" --home /data run-user && chown run-user:run-user -R /run/lock/apache2 /run/apache2 /var/log/apache2 /var/cache/apache2/ /data
 ENV APACHE_RUN_USER run-user
 ENV APACHE_RUN_GROUP run-user
-RUN a2enmod remoteip
-RUN echo "\nRemoteIPHeader X-Forwarded-For\nSetEnvIf X-Forwarded-Proto https HTTPS=on" >> /etc/apache2/apache2.conf
+RUN a2enmod remoteip && printf "\nRemoteIPHeader X-Forwarded-For\nSetEnvIf X-Forwarded-Proto https HTTPS=on" >> /etc/apache2/apache2.conf
 VOLUME /data

--- a/php-apache/7.2/Dockerfile
+++ b/php-apache/7.2/Dockerfile
@@ -2,16 +2,15 @@ FROM chialab/php:7.2-apache
 LABEL maintainer="HyperOne"
 LABEL rbx.shell_image="quay.io/hyperone/php-apache-shell:7.2"
 RUN rm -r /var/www/html && ln -s /data/public /var/www/html
-RUN echo "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_$(uname -m | sed 's/_/-/g').tar.gz"
-RUN curl "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_$(uname -m | sed 's/_/-/g').tar.gz" -o /tmp/ioncube.tar.gz \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -s "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_$(uname -m | sed 's/_/-/g').tar.gz" -o /tmp/ioncube.tar.gz \
 && extension_dir=$(php -i | sed -n -E '/extension_dir/s/^extension_dir.+?=> (.+?)/\1/gp') \
 && tar -xzvf /tmp/ioncube.tar.gz --strip-components=1 -C "$extension_dir" "ioncube/ioncube_loader_lin_7.2.so" \
 && chown root:staff "$extension_dir/ioncube_loader_lin_7.2.so" \
-&& echo "zend_extension = $extension_dir/ioncube_loader_lin_7.2.so" > /usr/local/etc/php/php.ini \
+&& printf "zend_extension = %s/ioncube_loader_lin_7.2.so" "$extension_dir" > /usr/local/etc/php/php.ini \
 && rm /tmp/ioncube.tar.gz
 RUN adduser -uid 23456 --disabled-password --gecos "" --home /data run-user && chown run-user:run-user -R /run/lock/apache2 /run/apache2 /var/log/apache2 /var/cache/apache2/ /data
 ENV APACHE_RUN_USER run-user
 ENV APACHE_RUN_GROUP run-user
-RUN a2enmod remoteip
-RUN echo "\nRemoteIPHeader X-Forwarded-For\nSetEnvIf X-Forwarded-Proto https HTTPS=on" >> /etc/apache2/apache2.conf
+RUN a2enmod remoteip && printf "\nRemoteIPHeader X-Forwarded-For\nSetEnvIf X-Forwarded-Proto https HTTPS=on" >> /etc/apache2/apache2.conf
 VOLUME /data

--- a/php-apache/base/Dockerfile
+++ b/php-apache/base/Dockerfile
@@ -2,16 +2,15 @@ FROM chialab/php:%%PHP_VERSION%%-apache
 LABEL maintainer="HyperOne"
 LABEL rbx.shell_image="quay.io/hyperone/php-apache-shell:%%PHP_VERSION%%"
 RUN rm -r /var/www/html && ln -s /data/public /var/www/html
-RUN echo "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_$(uname -m | sed 's/_/-/g').tar.gz"
-RUN curl "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_$(uname -m | sed 's/_/-/g').tar.gz" -o /tmp/ioncube.tar.gz \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -s "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_$(uname -m | sed 's/_/-/g').tar.gz" -o /tmp/ioncube.tar.gz \
 && extension_dir=$(php -i | sed -n -E '/extension_dir/s/^extension_dir.+?=> (.+?)/\1/gp') \
 && tar -xzvf /tmp/ioncube.tar.gz --strip-components=1 -C "$extension_dir" "ioncube/ioncube_loader_lin_%%PHP_VERSION%%.so" \
 && chown root:staff "$extension_dir/ioncube_loader_lin_%%PHP_VERSION%%.so" \
-&& echo "zend_extension = $extension_dir/ioncube_loader_lin_%%PHP_VERSION%%.so" > /usr/local/etc/php/php.ini \
+&& printf "zend_extension = %s/ioncube_loader_lin_%%PHP_VERSION%%.so" "$extension_dir" > /usr/local/etc/php/php.ini \
 && rm /tmp/ioncube.tar.gz
 RUN adduser -uid 23456 --disabled-password --gecos "" --home /data run-user && chown run-user:run-user -R /run/lock/apache2 /run/apache2 /var/log/apache2 /var/cache/apache2/ /data
 ENV APACHE_RUN_USER run-user
 ENV APACHE_RUN_GROUP run-user
-RUN a2enmod remoteip
-RUN echo "\nRemoteIPHeader X-Forwarded-For\nSetEnvIf X-Forwarded-Proto https HTTPS=on" >> /etc/apache2/apache2.conf
+RUN a2enmod remoteip && printf "\nRemoteIPHeader X-Forwarded-For\nSetEnvIf X-Forwarded-Proto https HTTPS=on" >> /etc/apache2/apache2.conf
 VOLUME /data


### PR DESCRIPTION
I introduced the hadolint and adapted to its requirements. Before the changes, it reported the following errors:

```
./php-apache/base/Dockerfile:6 DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it
./php-apache/base/Dockerfile:7 DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it
./php-apache/base/Dockerfile:13 DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./php-apache/base/Dockerfile:24 SC2028 echo may not expand escape sequences. Use printf.
./php-apache/7.2/Dockerfile:6 DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it
./php-apache/7.2/Dockerfile:7 DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it
./php-apache/7.2/Dockerfile:13 DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./php-apache/7.2/Dockerfile:24 SC2028 echo may not expand escape sequences. Use printf.
./php-apache/5.6/Dockerfile:6 DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it
./php-apache/5.6/Dockerfile:7 DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it
./php-apache/5.6/Dockerfile:13 DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./php-apache/5.6/Dockerfile:24 SC2028 echo may not expand escape sequences. Use printf.
./php-apache-shell/base/Dockerfile:5 DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./php-apache-shell/7.2/Dockerfile:5 DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./php-apache-shell/5.6/Dockerfile:5 DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
```
I do not think that we want to make all changes immediately. However, we can review rules, select which apply to facilitate future maintenance (as any tests), especially after transferring the task to fresh person.